### PR TITLE
Fix test failure reporting in verbose mode

### DIFF
--- a/Sources/Xproject/Services/SetupService.swift
+++ b/Sources/Xproject/Services/SetupService.swift
@@ -95,7 +95,7 @@ public final class SetupService: Sendable {
     /// Execute a brew command using the appropriate execution method based on verbose mode
     private func executeBrewCommand(_ command: String) async throws -> CommandResult {
         if verbose {
-            return try await executor.executeWithStreamingOutput(command)
+            return try await executor.executeWithStreamingOutputOrThrow(command)
         } else {
             return try executor.executeOrThrow(command)
         }

--- a/Sources/Xproject/Utilities/CommandExecuting.swift
+++ b/Sources/Xproject/Utilities/CommandExecuting.swift
@@ -20,8 +20,8 @@ public extension CommandExecuting {
         return try execute(command, environment: nil)
     }
 
-    func executeOrThrow(_ command: String) throws -> CommandResult {
-        let result = try execute(command, environment: nil)
+    func executeOrThrow(_ command: String, environment: [String: String]? = nil) throws -> CommandResult {
+        let result = try execute(command, environment: environment)
 
         if result.exitCode != 0 {
             throw CommandError.executionFailed(result: result)
@@ -36,5 +36,18 @@ public extension CommandExecuting {
 
     func executeWithStreamingOutput(_ command: String) async throws -> CommandResult {
         return try await executeWithStreamingOutput(command, environment: nil)
+    }
+
+    func executeWithStreamingOutputOrThrow(
+        _ command: String,
+        environment: [String: String]? = nil
+    ) async throws -> CommandResult {
+        let result = try await executeWithStreamingOutput(command, environment: environment)
+
+        if result.exitCode != 0 {
+            throw CommandError.executionFailed(result: result)
+        }
+
+        return result
     }
 }

--- a/Sources/Xproject/Utilities/XcodeClient.swift
+++ b/Sources/Xproject/Utilities/XcodeClient.swift
@@ -131,7 +131,7 @@ public final class XcodeClient: XcodeClientProtocol, Sendable {
 
         // Clean export directory
         if verbose {
-            _ = try await commandExecutor.executeWithStreamingOutput("rm -rf '\(exportPath)'")
+            _ = try await commandExecutor.executeWithStreamingOutputOrThrow("rm -rf '\(exportPath)'")
         } else {
             _ = try commandExecutor.executeOrThrow("rm -rf '\(exportPath)'")
         }
@@ -161,7 +161,7 @@ public final class XcodeClient: XcodeClientProtocol, Sendable {
         }
 
         if verbose {
-            _ = try await commandExecutor.executeWithStreamingOutput(uploadCommand)
+            _ = try await commandExecutor.executeWithStreamingOutputOrThrow(uploadCommand)
         } else {
             _ = try commandExecutor.executeOrThrow(uploadCommand)
         }
@@ -173,7 +173,7 @@ public final class XcodeClient: XcodeClientProtocol, Sendable {
         let reportsPath = config.reportsPath()
 
         if verbose {
-            _ = try await commandExecutor.executeWithStreamingOutput("rm -rf '\(buildPath)' '\(reportsPath)'")
+            _ = try await commandExecutor.executeWithStreamingOutputOrThrow("rm -rf '\(buildPath)' '\(reportsPath)'")
         } else {
             _ = try commandExecutor.executeOrThrow("rm -rf '\(buildPath)' '\(reportsPath)'")
         }
@@ -213,7 +213,7 @@ public final class XcodeClient: XcodeClientProtocol, Sendable {
 
         // Clean previous outputs
         if verbose {
-            _ = try await commandExecutor.executeWithStreamingOutput("rm -fr '\(xcodeLogFile)' '\(reportFile)' '\(resultFile)'")
+            _ = try await commandExecutor.executeWithStreamingOutputOrThrow("rm -fr '\(xcodeLogFile)' '\(reportFile)' '\(resultFile)'")
         } else {
             _ = try commandExecutor.executeOrThrow("rm -fr '\(xcodeLogFile)' '\(reportFile)' '\(resultFile)'")
         }
@@ -223,7 +223,7 @@ public final class XcodeClient: XcodeClientProtocol, Sendable {
                            "tee '\(xcodeLogFile)' | xcpretty --color --no-utf -r junit -o '\(reportFile)'"
 
         if verbose {
-            _ = try await commandExecutor.executeWithStreamingOutput(buildCommand)
+            _ = try await commandExecutor.executeWithStreamingOutputOrThrow(buildCommand)
         } else {
             _ = try commandExecutor.executeOrThrow(buildCommand)
         }


### PR DESCRIPTION
## Summary

Fixes a bug where command failures were not properly detected and reported when running in verbose mode. This affected both the test command and setup command.

## Problem

In verbose mode, both XcodeClient and SetupService were using `executeWithStreamingOutput` which returns a `CommandResult` but doesn't throw on failure. The results were being discarded, so when commands failed, no error was thrown and the commands incorrectly reported success.

This caused test failures to be silently ignored in verbose mode - tests would fail but the command would exit with success.

## Solution

Added `executeWithStreamingOutputOrThrow` as a default protocol extension method in `CommandExecuting` that:
- Calls `executeWithStreamingOutput` to get the result with streaming output
- Checks the exit code
- Throws `CommandError.executionFailed` if exit code != 0

Updated all verbose mode executions to use this method:
- **XcodeClient** (5 locations):
  - `executeXcodeBuild` - fixes the test reporting bug
  - `upload` command - fixes upload error handling  
  - `clean`, `generateIPA`, cleanup operations - for consistency
- **SetupService** (1 location):
  - `executeBrewCommand` - fixes brew command error handling

## Testing

- ✅ All 96 unit tests pass
- ✅ Command failures now correctly detected in verbose mode
- ✅ Command failures correctly detected in non-verbose mode
- ✅ Behavior is consistent between verbose and non-verbose modes

## Changes

- `CommandExecuting.swift`: Added `executeWithStreamingOutputOrThrow` as default protocol extension
- `XcodeClient.swift`: Updated 5 locations to use new method in verbose mode
- `SetupService.swift`: Updated brew command execution to use new method in verbose mode