### PR TITLE
refactor(xcode): remove xcpretty dependency from build pipeline

### DIFF
--- a/Sources/Xproject/Utilities/XcodeClient.swift
+++ b/Sources/Xproject/Utilities/XcodeClient.swift
@@ -204,7 +204,6 @@ public final class XcodeClient: XcodeClientProtocol, Sendable {
         let reportsPath = config.reportsPath()
 
         let xcodeLogFile = "\(buildPath)/xcode-\(reportName).log"
-        let reportFile = "\(reportsPath)/\(reportName).xml"
         let resultFile = "\(reportsPath)/\(reportName).xcresult"
 
         let allArgs = args + [
@@ -219,11 +218,11 @@ public final class XcodeClient: XcodeClientProtocol, Sendable {
 
         // Clean previous outputs
         // Note: Use non-streaming execute for rm commands since they produce no output
-        _ = try commandExecutor.executeOrThrow("rm -fr '\(xcodeLogFile)' '\(reportFile)' '\(resultFile)'")
+        _ = try commandExecutor.executeOrThrow("rm -fr '\(xcodeLogFile)' '\(resultFile)'")
 
-        // Execute xcodebuild with xcpretty
+        // Execute xcodebuild
         let buildCommand = "set -o pipefail && \(xcodeVersion) xcrun xcodebuild \(argsString) | " +
-                           "tee '\(xcodeLogFile)' | xcpretty --color --no-utf -r junit -o '\(reportFile)'"
+                           "tee '\(xcodeLogFile)'"
 
         if verbose {
             _ = try await commandExecutor.executeWithStreamingOutputOrThrow(buildCommand)


### PR DESCRIPTION
## Summary
- Remove xcpretty from xcodebuild pipeline in `XcodeClient`
- Remove JUnit report generation (no longer needed)
- Simplify build command to just use `tee` for log capture

The xcresult bundles already contain all build/test information needed for reporting via `xp pr-report`, making xcpretty and JUnit reports redundant.

## Test plan
- [x] All 392 tests passing
- [x] swiftlint clean
- [ ] Verify build command works correctly without xcpretty