### PR TITLE
Broaden tool allowlist for claude-code-review workflow

### DIFF
--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -46,6 +46,12 @@ jobs:
           plugin_marketplaces: 'https://github.com/anthropics/claude-code.git'
           plugins: 'code-review@claude-code-plugins'
           prompt: '/code-review:code-review ${{ github.repository }}/pull/${{ github.event.pull_request.number || github.event.issue.number }}'
+          # The code-review slash command's frontmatter only allows gh CLI tools
+          # plus the inline-comment MCP. Add the read-only tools a real review
+          # needs (file inspection, codebase search, git history) so the agent
+          # is not burning turns on permission denials.
+          claude_args: |
+            --allowedTools "Read,Grep,Glob,Bash(git diff:*),Bash(git log:*),Bash(git show:*),Bash(git blame:*),Bash(rg:*)"
           # See https://github.com/anthropics/claude-code-action/blob/main/docs/usage.md
           # or https://code.claude.com/docs/en/cli-reference for available options
 

--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -35,7 +35,9 @@ jobs:
       - name: Checkout repository
         uses: actions/checkout@v6
         with:
-          fetch-depth: 1
+          # Full history so the allowlisted git log/show/blame commands return
+          # meaningful results to the review agent. Matches release.yml/tests.yml.
+          fetch-depth: 0
           ref: ${{ github.event.pull_request.head.sha || format('refs/pull/{0}/head', github.event.issue.number) }}
 
       - name: Run Claude Code Review


### PR DESCRIPTION
## Summary

The `code-review@claude-code-plugins` slash command this workflow invokes only allowlists `gh` subcommands plus the inline-comment MCP — no `Read`, `Grep`, `Glob`, or `git` tools. Without those, the review agent burns turns on permission denials trying to inspect files and ends up posting nothing.

Observed on PR #49 (before merge):

| Run | Permission denials | Inline comments posted |
|-----|--------------------|------------------------|
| 26475089303 | 10 | 0 |
| 26475953369 | 39 | 0 |

Both runs reported workflow-level "success" while doing nothing useful — costly silence.

## What this changes

Adds `claude_args` to the workflow step with a read-only tool augmentation:

```yaml
claude_args: |
  --allowedTools "Read,Grep,Glob,Bash(git diff:*),Bash(git log:*),Bash(git show:*),Bash(git blame:*),Bash(rg:*)"
```

These augment (not replace) the slash command's frontmatter allowlist.

## Security

No new exposure surface:

- All added tools are **read-only** (no `Edit`, no `Write`, no `Bash(rm:*)`, no `gh pr comment` beyond what's already allowed).
- The workflow's only secrets are `CLAUDE_CODE_OAUTH_TOKEN` and the runtime `GITHUB_TOKEN`, both registered with `core.setSecret()` and auto-masked in logs.
- The runner has no access to `EJSON_PRIVATE_KEY`, `PROVISION_PASSWORD`, or any other project secret — those only live on `release.yml`.

## Why a separate PR

GitHub's code-review workflow validation refuses to issue the App token on PRs whose `claude-code-review.yml` differs from `main`. That's by design — prevents a malicious PR from rewriting the review workflow to exfiltrate the bot's token. The corollary is that this change can only be validated *after* it lands on `main`; the next PR opened after merge will be the real test.

## Test plan

- [ ] Merge this PR
- [ ] Open any subsequent PR and confirm the `claude-code-review` workflow run produces non-zero inline comments (or a substantive summary review) and the `permission_denials_count` drops significantly
