### PR TITLE
Silence unused-result warnings on createMockProfile

### DIFF
--- a/Tests/XprojectTests/Services/ProvisionServiceTests.swift
+++ b/Tests/XprojectTests/Services/ProvisionServiceTests.swift
@@ -24,6 +24,7 @@ struct ProvisionServiceTests {
     }
 
     /// Creates a mock .mobileprovision file
+    @discardableResult
     private func createMockProfile(in directory: String, name: String, content: String? = nil) throws -> String {
         let profilePath = (directory as NSString).appendingPathComponent(name)
         let data = (content ?? "Mock provisioning profile content for \(name)").data(using: .utf8)!


### PR DESCRIPTION
## Summary

Adds `@discardableResult` to `ProvisionServiceTests.createMockProfile`. Roughly a dozen call sites in `ProvisionServiceTests.swift` invoke it for the side effect (writing a mock `.mobileprovision` file) and discard the returned path. Under Swift 6.2 strict diagnostics each emits a `[#no-usage]` warning. One-character change to the helper silences all of them — confirmed locally: `XprojectTests` builds with zero warnings after.

## Test plan

- [x] `swift build --target XprojectTests` — clean, no warnings
- [x] `swift test --filter ProvisionService` — still passes
- [x] Validate that the `claude-code-review` workflow now produces a useful review (this is the first PR after #50 merged — the real point of opening it)
